### PR TITLE
extend notebook to easily cover somalia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ book_syr_drought/_book/
 book_syr_drought/_publish.yml
 
 book_syr_drought/_freeze/
+.scrapy/*

--- a/book_syr_drought/02_era5.qmd
+++ b/book_syr_drought/02_era5.qmd
@@ -89,7 +89,8 @@ box::use(
     terra[...],
     tidyterra[...],
     patchwork[...],
-    sf[...]
+    sf[...],
+    gt[...]
 )
 
 
@@ -167,6 +168,24 @@ ggplot() +
         title = glue("Rainfall Return Periods"),
         caption = "Higher return periods indicate rarer low-rainfall events"
     )
+
+
+gdf_sel |> 
+  st_drop_geometry() |> 
+  arrange(desc(return_period)) |> 
+  select(ADM1_EN, return_period) |>
+  gt() |> 
+  fmt_number(
+    columns = return_period,
+    decimals = 1,
+    use_seps = TRUE) |> 
+  cols_label(
+    ADM1_EN = "Province",
+    return_period = "Return Period"
+  ) |> 
+  tab_options(
+    column_labels.background.color = "#55b284ff"
+  )
 ```
 
 

--- a/book_syr_drought/02_era5.qmd
+++ b/book_syr_drought/02_era5.qmd
@@ -88,15 +88,24 @@ box::use(
     stringr[...],
     terra[...],
     tidyterra[...],
-    patchwork[...]
+    patchwork[...],
+    sf[...]
 )
 
-iso3 <- "SYR"
+
+# For raster processing from Azure Storage
+Sys.setenv("AZURE_STORAGE_ACCOUNT"=Sys.getenv("DSCI_AZ_PROD_STORAGE_ACCOUNT"))
+Sys.setenv("AZURE_STORAGE_SAS_TOKEN"=Sys.getenv("DSCI_AZ_BLOB_PROD_SAS"))
+
+
+iso3 <- c("SYR","SOM")[2]
 adm_level <- 1
 dataset <- "era5"
-months_to_include <- c(11, 12, 1, 2, 3, 4)
+months_to_include <- list("SYR" = c(11, 12, 1, 2, 3, 4),"SOM"= c(3,4,5,6))[[iso3]]
 year <- 2025
 gdf <- cumulus::download_fieldmaps_sf(iso3, glue("{iso3}_adm{adm_level}"))[[1]]
+gdf_bbox <- ext(st_bbox(gdf) )
+
 
 pcode_col <- "ADM1_PCODE"
 
@@ -164,11 +173,9 @@ ggplot() +
 ## Percipitation anomalies
 
 ```{r}
-
 proj_container <- cumulus::blob_containers("dev")$projects
-rast_container <- cumulus::blob_containers("prod")$raster
-tmp_dir <- "tmp/"
-azure_dir <- "ds-seasonal-bulletin/"
+rast_container <- cumulus::blob_containers("prod",write_access = F)$raster
+
 src_cog_dir <- paste0(dataset, "/monthly/processed")
 
 cog_df <- get_cogs_to_process(
@@ -181,9 +188,10 @@ cog_df <- get_cogs_to_process(
 
 yearly_sums <- list()
 for (sel_year in unique(cog_df$season_year)) {
+  cat(sel_year,"\n")
   yearly_cogs <- filter(cog_df, year == sel_year)
   urls <- paste0("/vsiaz/raster/", yearly_cogs$name)
-  cogs <- rast(urls)
+  cogs <- rast(urls, win = gdf_bbox)
   cogs_clipped <- crop(cogs, gdf)
   cogs_masked <- mask(cogs_clipped, gdf)
   # go from mm/day to mm/month

--- a/book_syr_drought/02_era5.qmd
+++ b/book_syr_drought/02_era5.qmd
@@ -90,7 +90,8 @@ box::use(
     tidyterra[...],
     patchwork[...],
     sf[...],
-    gt[...]
+    gt[...],
+    forcats[...]
 )
 
 
@@ -152,8 +153,150 @@ gdf_lower <- gdf_sel %>%
     filter(is_lower_tercile == TRUE)
 ```
 
+```{r}
+# look at ERA5 RPs by month - code taken from ASI analysis
+rp_empirical <- function(x, direction = c("1", "-1"), ties_method = "average") {
+    direction <- as.numeric(rlang::arg_match(direction))
+    rank <- rank(x * direction, ties.method = ties_method)
+    q_rank <- rank / (length(x) + 1)
+    rp <- 1 / q_rank
+    return(rp)
+}
 
-## Return periods per Province
+# needed for plot labels
+adm_lookup <- blob_load_admin_lookup()
+adm1_lookup <- adm_lookup |> 
+  filter(!is.na(ADM1_NAME)) |> 
+  distinct(ADM1_NAME,ADM1_PCODE) |> 
+  rename(ADM1_EN = ADM1_NAME)
+
+
+df_filtered <- df_era5 |>
+  left_join(
+    adm1_lookup, by= c("pcode"="ADM1_PCODE")
+  ) |> 
+    mutate(
+      year = year(valid_date),
+      month= month(valid_date, abbr= T),
+        mo_num = month(valid_date),
+      # not relevant for current ERA5 season, but generally might 
+      # be useful to leave in for later
+        harvest_year = case_when(
+            mo_num %in% c(11, 12) ~ year + 1,
+            TRUE ~ year
+        ),
+        mo_chr = fct_expand(month.abb[mo_num], month.abb)
+    ) |>
+    filter(
+
+        # June/early july should be peak growing from Gu rainfall
+        mo_num %in% months_to_include
+    ) |>
+    mutate(
+        mo_fct = fct_relevel(mo_chr,month.abb[months_to_include]),
+        harvest_year_label = case_when(
+            harvest_year %in% c(2023:2025) ~ as.character(harvest_year),
+            .default = "Other"
+        ),
+        alpha_flag = if_else(harvest_year_label == "Other", "low", "high") # for alpha mapping
+    )
+
+df_rps <- df_filtered |>
+    group_by(pcode,ADM1_EN, mo_num, mo_chr) |>
+    mutate(
+        rp_empirical = rp_empirical(
+            mean,
+            ties_method = "average",
+            direction = "1"
+        ),
+        mm = days_in_month(valid_date) * mean,
+        abs_anomaly = mm - mean(mm, na.rm = TRUE),
+    ) |>
+    arrange(
+        pcode, mo_chr
+    )
+
+
+# will label 2025 line with the RPS for each month
+df_rps_2025 <- df_rps |>
+    filter(
+        harvest_year == 2025
+    )
+```
+
+
+```{r}
+north_adm1 <- c(
+  "Awdal","Woqooyi Galbeed","Togdheer","Sanaag","Sool",
+  "Bari"
+)
+#    keep the rest in their existing order
+levels_all <- unique(df_rps$ADM1_EN)
+facet_levels <- c(north_adm1, setdiff(levels_all, north_adm1))
+
+df_rps <- df_rps %>%
+  mutate(ADM1_EN = factor(ADM1_EN, levels = facet_levels))
+
+df_rps_2025 <- df_rps_2025 %>%
+  mutate(ADM1_EN = factor(ADM1_EN, levels = facet_levels))
+
+# 3) data frame to draw a red outline ONLY on northern facets
+box_df <- tibble(
+  ADM1_EN = factor(north_adm1, levels = facet_levels),
+  xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf
+)
+
+df_rps |>
+    mutate(
+        # mo_fct = fct_relevel(mo_chr, c("Nov", "Dec", "Jan", "Feb", "Mar", "Apr")),
+        harvest_year_label = case_when(
+            harvest_year %in% c(2023:2025) ~ as.character(harvest_year),
+            .default = "Other"
+        ),
+        alpha_flag = if_else(harvest_year_label == "Other", "low", "high") # for alpha mapping
+    ) |>
+    ggplot(
+        aes(
+            x = mo_fct,
+            y = abs_anomaly,
+            group = harvest_year,
+            color = harvest_year_label,
+            alpha = alpha_flag
+        )
+    ) +
+    # red box around northern facets
+  geom_rect(
+    data = box_df,
+    aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax),
+    inherit.aes = FALSE,
+    color = "tomato", fill = NA, linewidth = 1
+  ) +
+    geom_text(
+        data = df_rps_2025,
+        aes(label = scales::number(rp_empirical, accuracy = 1), vjust = -.5),
+        show.legend = FALSE, size=4
+    ) +
+
+    expand_limits(y = max(df_filtered$mean, na.rm = TRUE) * 1.3) +
+    labs(
+      title = "Seasonal progression of rainfall defecit over the Gu season per region",
+      color = "Harvest Year",
+      y = "mm deficit",
+      caption = "Approximate return periods labelled for current year (2025)\nNorthern regions highlighted in red"
+      ) +
+    scale_alpha_manual(values = c("low" = 0.3, "high" = 1), guide = "none") +
+    geom_line() +
+    facet_wrap(~ADM1_EN) +
+    theme(
+      plot.title = element_text(size=20),
+        axis.text.x = element_text(angle = 90,size=14),
+        axis.text.y = element_text(angle = 0,size=14),
+        strip.text = element_text(size=16),
+        axis.title.x = element_blank(),plot.caption = element_text(hjust=0)
+    )
+```
+
+## Return periods per region
 
 ```{r}
 ggplot() +
@@ -187,6 +330,7 @@ gdf_sel |>
     column_labels.background.color = "#55b284ff"
   )
 ```
+
 
 
 ## Percipitation anomalies


### PR DESCRIPTION
This pull request updates the ERA5 data processing workflow for drought analysis to support both Syria (`SYR`) and Somalia (`SOM`), adjusts raster handling/querying from Azure Storage. I guess since it's a Somalia analysis idk if it really makes sense in this repo. But for the time being it has to live somewhere. I guess if we mainstream these types of analayses more globally somewhere (maybe bulletins) we can migrate this type of code and eventually get rid of it here?

**Multi-country support and configuration:**
* Refactored the `iso3` variable to allow selection between `SYR` and `SOM`, and updated `months_to_include` to configure months per country for seasonal analysis.

**Azure Storage integration:**
* Added environment variable setup for Azure Storage account and SAS token to enable secure raster processing directly from cloud storage.
* Updated raster container access to use read-only mode for production (`write_access = F`).

**Spatial processing improvements:**
* Introduced `gdf_bbox` to define the bounding box for the selected administrative area, enabling efficient windowed loading of rasters.
* Modified raster loading (`rast()`) to use the bounding box window (`win = gdf_bbox`), improving performance and focusing processing on the area of interest.

**Dependency updates:**
* Added the `{sf}` package to the dependency list for enhanced spatial data handling.
* Added `{gt}` for tabling